### PR TITLE
fix reading from a boolean column

### DIFF
--- a/src/jdbc/impl.clj
+++ b/src/jdbc/impl.clj
@@ -195,7 +195,7 @@
   (from-sql-type [this conn metadata i] this)
 
   Boolean
-  (from-sql-type [this conn metadata i] (if (true? this) this false))
+  (from-sql-type [this conn metadata i] (= true this))
 
   nil
   (from-sql-type [this conn metadata i] nil))


### PR DESCRIPTION
Using clojure.jdbc with MSSQL database, reading values from boolean columns seems to always return 'false'.
The ResultSet contains the correct value ('true'), but applying true? to it always return false, since true? uses identical comparison.